### PR TITLE
Fix: Notification Display Order and Add Cyclic Behavior

### DIFF
--- a/Azkar/src/main/java/com/bayoumi/util/services/EditablePeriodTimerTask.java
+++ b/Azkar/src/main/java/com/bayoumi/util/services/EditablePeriodTimerTask.java
@@ -36,8 +36,6 @@ public class EditablePeriodTimerTask extends TimerTask {
     public final void updateTimer() {
         Long p = period.get();
         Objects.requireNonNull(p);
-//        System.out.println("updateTimer():- " + Thread.currentThread().getName());
-//        System.out.println("updateTimer():- " + "new : " + p);
         Logger.debug(String.format("Period set to: %d s", p / 1000));
         stopTask();
         timer = new Timer();
@@ -46,7 +44,6 @@ public class EditablePeriodTimerTask extends TimerTask {
 
     public void stopTask() {
         if (timer != null) {
-//            this.cancel();
             timer.cancel();
             timer.purge();
         }
@@ -57,7 +54,6 @@ public class EditablePeriodTimerTask extends TimerTask {
     public void run() {
         task.run();
         Logger.debug("run():- " + Thread.currentThread().getName());
-//        updateTimer("run()");
     }
 
 }

--- a/Azkar/src/main/java/com/bayoumi/util/services/azkar/AzkarService.java
+++ b/Azkar/src/main/java/com/bayoumi/util/services/azkar/AzkarService.java
@@ -11,8 +11,6 @@ import javafx.application.Platform;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
-import java.util.Random;
-
 public class AzkarService {
 
     private static EditablePeriodTimerTask absoluteAzkarTask;
@@ -48,11 +46,11 @@ public class AzkarService {
                 return;
             }
 
-           final AbsoluteZekr currentZekr = AbsoluteZekr.absoluteZekrObservableList.get(currentZekrIndex);
+            final AbsoluteZekr currentZekr = AbsoluteZekr.absoluteZekrObservableList.get(currentZekrIndex);
 
             Platform.runLater(()
                     -> Notification.create(new NotificationContent(currentZekr.getText(), null),
-                        Settings.getInstance().getAzkarSettings().getAzkarDuration(),
+                    Settings.getInstance().getAzkarSettings().getAzkarDuration(),
                     Settings.getInstance().getNotificationSettings().getPosition(),
                     null,
                     new NotificationAudio(Settings.getInstance().getAzkarSettings().getAudioName(), Settings.getInstance().getAzkarSettings().getVolume())));

--- a/Azkar/src/main/java/com/bayoumi/util/services/azkar/AzkarService.java
+++ b/Azkar/src/main/java/com/bayoumi/util/services/azkar/AzkarService.java
@@ -46,7 +46,12 @@ public class AzkarService {
                 return;
             }
 
-            final AbsoluteZekr currentZekr = AbsoluteZekr.absoluteZekrObservableList.get(currentZekrIndex);
+            AbsoluteZekr currentZekr;
+            if (currentZekrIndex >= 0 && currentZekrIndex < AbsoluteZekr.absoluteZekrObservableList.size()) {
+                currentZekr = AbsoluteZekr.absoluteZekrObservableList.get(currentZekrIndex);
+            } else {
+                currentZekr = AbsoluteZekr.absoluteZekrObservableList.get(0); // Fallback to the first item
+            }
 
             Platform.runLater(()
                     -> Notification.create(new NotificationContent(currentZekr.getText(), null),

--- a/Azkar/src/main/java/com/bayoumi/util/services/azkar/AzkarService.java
+++ b/Azkar/src/main/java/com/bayoumi/util/services/azkar/AzkarService.java
@@ -17,6 +17,7 @@ public class AzkarService {
 
     private static EditablePeriodTimerTask absoluteAzkarTask;
     public static Stage FAKE_STAGE;
+    private static int currentZekrIndex = 0;
 
     public static void stopService() {
         if (AzkarService.absoluteAzkarTask != null) {
@@ -46,14 +47,16 @@ public class AzkarService {
             if (AbsoluteZekr.absoluteZekrObservableList.isEmpty()) {
                 return;
             }
+
+            AbsoluteZekr currentZekr = AbsoluteZekr.absoluteZekrObservableList.get(currentZekrIndex);
+
             Platform.runLater(()
-                    -> Notification.create(new NotificationContent(AbsoluteZekr.absoluteZekrObservableList.get(
-                            new Random().nextInt(AbsoluteZekr.absoluteZekrObservableList.size())).getText(),
-                            null),
+                    -> Notification.create(new NotificationContent(currentZekr.getText(), null),
                     30,
                     Settings.getInstance().getNotificationSettings().getPosition(),
                     null,
                     new NotificationAudio(Settings.getInstance().getAzkarSettings().getAudioName(), Settings.getInstance().getAzkarSettings().getVolume())));
+            currentZekrIndex = (currentZekrIndex + 1) % AbsoluteZekr.absoluteZekrObservableList.size();
         },
                 azkarPeriodsController::getPeriod);
         absoluteAzkarTask.updateTimer();


### PR DESCRIPTION
#### **Description**
fixes the issue where notifications in `AzkarService` were shown in a random order, leading to potential repetition and lack of sequential display. The proposed changes ensure that:
1. Notifications are shown **in order** from the `AbsoluteZekr.absoluteZekrObservableList`.
2. After displaying the last notification, the system **loops back** to the first one, creating a cyclic slider-like behavior.
3. Each notification is only shown **once per cycle**, preventing duplicates within the same round.

#### **Related Issue**
Closes #70  - *Notifications Repeated Randomly and Lack of Sequential Display*

#### **Changes Made**
- Introduced an **index tracking mechanism** (`currentZekrIndex`) to keep track of the current notification being displayed.
- Replaced the random selection logic with **sequential display**.
- Used a **modulo operation** to ensure the index loops back to the start once all notifications have been displayed.
- Removed the possibility of displaying duplicate notifications until the full list has been cycled through.

#### **Affected Files**
- `AzkarService.java`

#### **Testing Done**
- Verified that notifications now display in the order they appear in the list.
- Confirmed that after the last notification is shown, the system loops back to the first one.
- Ensured that no duplicate notifications are displayed until a full cycle has been completed.

#### **Screenshots/Examples (if applicable)**
N/A
